### PR TITLE
✨ chore: ignore .DS_Store files in .gitignore for cleanliness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+############################################## CUSTOM ############################################## 
+.DS_Store 


### PR DESCRIPTION
### Description

- Added `.DS_Store` to `.gitignore` to prevent these files from being tracked
- Improved repository cleanliness by ignoring macOS system files